### PR TITLE
Allow default to be generated from an ```attr.Factory``` callable.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changes:
 
 - Added ``environ.generate_help(AppConfig)`` to create a help string based on the configuration.
 - Added ``AppConfig.from_environ()`` to instantiate the config class without importing the ``environ`` module.
+- If ``environ.var`` is passed an ``attr.Factory``, the callable is used to generate the default value.
+
 
 
 ----

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -108,7 +108,14 @@ def to_config(config_cls, environ=os.environ):
             var = ("_".join(app_prefix + prefix + (name,))).upper()
 
         log.debug("looking for env var '%s'." % (var,))
-        val = environ.get(var, ce.default)
+        val = environ.get(
+            var,
+            (
+                attr.NOTHING
+                if isinstance(ce.default, attr.Factory)
+                else ce.default
+            ),
+        )
         if val is RAISE:
             raise MissingEnvValueError(var)
         return val

--- a/tests/test_class_to_config.py
+++ b/tests/test_class_to_config.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import attr
+
 import environ
 
 
@@ -28,3 +30,19 @@ def test_env():
 
     assert cfg.host == "0.0.0.0"
     assert cfg.port == 5000
+
+
+def test_factory_default():
+    """
+    Class based ``from_environ`` allows ``attr.Factory`` defaults.
+    """
+
+    @environ.config()
+    class FactoryConfig(object):
+        x = environ.var(attr.Factory(list))
+        y = environ.var("bar")
+
+    cfg = FactoryConfig.from_environ({"APP_Y": "baz"})
+
+    assert cfg.x == []
+    assert cfg.y == "baz"

--- a/tests/test_environ_config.py
+++ b/tests/test_environ_config.py
@@ -125,6 +125,21 @@ class TestEnvironConfig(object):
 
         assert Defaults(x="foo", y="bar") == cfg
 
+    def test_factory_default(self):
+        """
+        If the default value is an ``attr.Factory``,
+        it used to generate the default value.
+        """
+
+        @environ.config
+        class Defaults(object):
+            x = environ.var(attr.Factory(list))
+            y = environ.var(attr.Factory(list))
+
+        cfg = environ.to_config(Defaults, environ={"APP_Y": "bar"})
+
+        assert Defaults(x=[], y="bar") == cfg
+
     @pytest.mark.parametrize("prefix", [None, ""])
     def test_no_prefix(self, prefix):
         """

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -94,6 +94,23 @@ class TestIniSecret(object):
 
         assert Cfg("foobar", "used!") == cfg
 
+    def test_default_factory(self, ini):
+        """
+        Defaults are used iff the key is missing.
+        """
+
+        def getpass():
+            return "thesecret"
+
+        @environ.config
+        class Cfg(object):
+            password = ini.secret(default=attr.Factory(getpass))
+            secret = ini.secret(default=attr.Factory(getpass))
+
+        cfg = environ.to_config(Cfg, {})
+
+        assert Cfg("foobar", "thesecret") == cfg
+
     def test_name_overwrite(self, ini):
         """
         Passsing a specific key name is respected.


### PR DESCRIPTION
It would be nice to allow callable defaults (e.g. can have a var default to ```getpass.getpass```).

This sets default to ```NOTHING``` if a ```Factory```, which causes ```attrs``` to call the factory.

This relies on potentially internal/undocumented behavior in ```attrs```, so happy for any feedback and whether this approach is reasonable.
