### PR TITLE
Support frozen configs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ Features
   * INI files, because secrets in env variables are `icky <https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/>`_.
 - Pass any dict into ``environ.to_config(AppConfig, {"your": "config"})`` instead of loading from the environment.
 - Built in dynamic help documentation generation via ``environ.generate_help``.
+- Support immutable config classes via ``@environ.config(frozen=True)``.
 
 .. code-block:: pycon
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Features
   * INI files, because secrets in env variables are `icky <https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/>`_.
 - Pass any dict into ``environ.to_config(AppConfig, {"your": "config"})`` instead of loading from the environment.
 - Built in dynamic help documentation generation via ``environ.generate_help``.
-- Support immutable config classes via ``@environ.config(frozen=True)``.
+- Your config can be immutable via ``@environ.config(frozen=True)``.
 
 .. code-block:: pycon
 

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -41,6 +41,7 @@ def config(
     prefix="APP",
     from_environ="from_environ",
     generate_help="generate_help",
+    frozen=False,
 ):
     def wrap(cls):
         def from_environ_fnc(cls, environ=os.environ):
@@ -58,7 +59,7 @@ def config(
             setattr(cls, from_environ, classmethod(from_environ_fnc))
         if generate_help is not None:
             setattr(cls, generate_help, classmethod(generate_help_fnc))
-        return attr.s(cls, slots=True)
+        return attr.s(cls, frozen=frozen, slots=True)
 
     if maybe_cls is None:
         return wrap

--- a/tests/test_environ_config.py
+++ b/tests/test_environ_config.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 import attr
 import pytest
+from attr.exceptions import FrozenInstanceError
 
 import environ
 
@@ -282,3 +283,41 @@ FOO_CHILD_VAR14 (Required)"""
 
         help_str = environ.generate_help(Parent, formatter=bad_formatter)
         assert help_str == "Not a good formatter"
+
+    def test_frozen(self):
+        @environ.config(frozen=True)
+        class Cfg(object):
+            x = environ.var()
+            y = environ.var()
+
+        cfg = environ.to_config(
+            Cfg, {"APP_X": "foo", "APP_Y": "bar"}
+        )
+
+        with pytest.raises(FrozenInstanceError):
+            cfg.x = "next_foo"
+
+        assert cfg.x == "foo"
+
+    def test_frozen_child(self):
+        @environ.config
+        class Cfg(object):
+            @environ.config(frozen=True)
+            class Sub(object):
+                z = environ.var()
+
+            x = environ.var()
+            y = environ.var()
+            sub = environ.group(Sub)
+
+        cfg = environ.to_config(
+            Cfg, {"APP_X": "foo", "APP_Y": "bar", "APP_SUB_Z": "baz"}
+        )
+
+        cfg.x = "next_foo"
+        assert cfg.x == "next_foo"
+
+        with pytest.raises(FrozenInstanceError):
+            cfg.sub.z = "next_baz"
+
+        assert cfg.sub.z == "baz"

--- a/tests/test_environ_config.py
+++ b/tests/test_environ_config.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 import attr
 import pytest
+
 from attr.exceptions import FrozenInstanceError
 
 import environ
@@ -285,14 +286,14 @@ FOO_CHILD_VAR14 (Required)"""
         assert help_str == "Not a good formatter"
 
     def test_frozen(self):
+        """Immutable config."""
+
         @environ.config(frozen=True)
         class Cfg(object):
             x = environ.var()
             y = environ.var()
 
-        cfg = environ.to_config(
-            Cfg, {"APP_X": "foo", "APP_Y": "bar"}
-        )
+        cfg = environ.to_config(Cfg, {"APP_X": "foo", "APP_Y": "bar"})
 
         with pytest.raises(FrozenInstanceError):
             cfg.x = "next_foo"
@@ -300,6 +301,8 @@ FOO_CHILD_VAR14 (Required)"""
         assert cfg.x == "foo"
 
     def test_frozen_child(self):
+        """Child group is immutable."""
+
         @environ.config
         class Cfg(object):
             @environ.config(frozen=True)


### PR DESCRIPTION
Allow passing ``frozen=True`` to ``@environ.config`` to enforce immutable config classes.

Issue: #11