### PR TITLE
Fix help generation when prefix is empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Fixed environment variables' names when prefix is empty.
+  `#14 <https://github.com/hynek/environ-config/pull/14>`_
+
 
 
 ----

--- a/tests/test_environ_config.py
+++ b/tests/test_environ_config.py
@@ -62,6 +62,13 @@ class Parent(object):
     child = environ.group(Child)
 
 
+@environ.config(prefix="")
+class NoPrefix(object):
+    a_var = environ.var(help="a_var, no default")
+    another_var = environ.var("bar", help="another_var, has default")
+    _start_with_underscore = environ.var(help="this starts with an underscore")
+
+
 class TestEnvironConfig(object):
     def test_empty(self):
         """
@@ -277,6 +284,19 @@ DOG2 (Optional, Default=canine): var11, named, has default
 CAT2 (Required): var12, named, no default
 FOO_CHILD_VAR13 (Optional, Default=default)
 FOO_CHILD_VAR14 (Required)"""
+        )
+
+    def test_generate_help_str_when_prefix_is_empty(self):
+        """
+        Environment variables' names don't start with an underscore
+        """
+        help_str = environ.generate_help(NoPrefix)
+
+        assert (
+            help_str
+            == """A_VAR (Required): a_var, no default
+ANOTHER_VAR (Optional): another_var, has default
+_START_WITH_UNDERSCORE (Required): this starts with an underscore"""
         )
 
     def test_custom_formatter(self):


### PR DESCRIPTION
# Scope

Currently, if prefix is set to an empty string, the generated help environment variables will all start by underscore, e.g. `_THIS_IS_A_VAR` instead of `THIS_IS_A_VAR`. 

This PR aims at fixing this issue.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/environ-config/blob/master/.github/CONTRIBUTING.rst) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/environ-config/blob/master/src/environ_config/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
