### PR TITLE
improv: Add `optional` argument for groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Versions follow `CalVer <http://calver.org>`_ with *no* backward-compatibility g
 The third digit is only for regressions.
 
 
-20.2.0 (UNRELEASED)
+21.1.0 (UNRELEASED)
 -------------------
 
 
@@ -25,7 +25,8 @@ Changes:
 
 - Fixed environment variables' names when prefix is empty.
   `#14 <https://github.com/hynek/environ-config/pull/14>`_
-
+- Added the ``optional`` keyword argument to ``environ.group()``
+  `#17 <https://github.com/hynek/environ-config/pull/17>`_
 
 
 ----

--- a/src/environ/__init__.py
+++ b/src/environ/__init__.py
@@ -24,7 +24,7 @@ from ._environ_config import (
 from .exceptions import MissingEnvValueError
 
 
-__version__ = "20.2.0.dev0"
+__version__ = "21.1.0.dev0"
 
 __title__ = "environ_config"
 __description__ = "Boilerplate-free configuration with env variables."

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -335,7 +335,7 @@ def _generate_help_dicts(config_cls, _prefix=None):
                 var_name = _generate_var_name(_prefix, a.name)
             else:
                 var_name = ce.name
-            req = ce.default == RAISE
+            req = isinstance(ce.default, Raise)
             help_dict = {"var_name": var_name, "required": req}
             if not req:
                 help_dict["default"] = ce.default

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -16,11 +16,14 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+import sys
 
 import attr
 
 from .exceptions import MissingEnvValueError
 
+
+PY2 = sys.version_info[0] == 2
 
 CNF_KEY = "environ_config"
 log = logging.getLogger(CNF_KEY)
@@ -35,7 +38,8 @@ class Sentinel(object):
     def __bool__(self):
         return self._bool
 
-    __nonzero__ = __bool__  # For Python 2 compatibility
+    if PY2:
+        __nonzero__ = __bool__
 
 
 PREFIX_NOT_SET = Sentinel(False)

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -110,7 +110,7 @@ class INISecrets(object):
         if ce.name is not None:
             var = ce.name
         else:
-            var = "_".join((prefix + (name,)))
+            var = "_".join((prefix[1:] + (name,)))
         try:
             log.debug("looking for '%s' in section '%s'." % (var, section))
             return _SecretStr(self._cfg.get(section, var))
@@ -154,7 +154,7 @@ class VaultEnvSecrets(object):
                 vp = self.vault_prefix(environ)
             else:
                 vp = self.vault_prefix
-            var = "_".join(((vp,) + prefix + (name,))).upper()
+            var = "_".join(((vp,) + prefix[1:] + (name,))).upper()
 
         log.debug("looking for env var '%s'." % (var,))
         val = environ.get(

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -26,7 +26,7 @@ from configparser import NoOptionError, RawConfigParser
 
 import attr
 
-from ._environ_config import CNF_KEY, RAISE, _ConfigEntry
+from ._environ_config import CNF_KEY, RAISE, Raise, _ConfigEntry
 from .exceptions import MissingSecretError
 
 
@@ -117,7 +117,7 @@ class INISecrets(object):
         except NoOptionError:
             if isinstance(ce.default, attr.Factory):
                 return attr.NOTHING
-            elif ce.default is not RAISE:
+            elif not isinstance(ce.default, Raise):
                 return ce.default
             raise MissingSecretError(var)
 
@@ -165,7 +165,7 @@ class VaultEnvSecrets(object):
                 else ce.default
             ),
         )
-        if val is RAISE:
+        if isinstance(val, Raise):
             raise MissingSecretError(var)
         return _SecretStr(val)
 


### PR DESCRIPTION
This argument allows the programmer to alter their group so that if all
of the required sub-vars are missing, the group will simply be set to
`None`. This is useful for grouping configuration variables which must
all be defined, or ignored entirely.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/environ-config/blob/master/.github/CONTRIBUTING.rst) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/environ-config/blob/master/src/environ_config/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
