### PR TITLE
Directory secret reader

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Changes:
   `#14 <https://github.com/hynek/environ-config/pull/14>`_
 - Added the ``optional`` keyword argument to ``environ.group()``
   `#17 <https://github.com/hynek/environ-config/pull/17>`_
+- Added ``DirectorySecrets`` secret reader, which can read secrets from a directory of files.
+  Useful for Docker or Kubernetes mounted secrets inside a container.
+  `#19 <https://github.com/hynek/environ-config/pull/19>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,9 @@ Secrets
 
       Please note that `it's a bad idea to store secrets in environment variables <https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/>`_.
 
+.. autoclass:: DirectorySecrets
+   :members: from_docker, from_path, from_path_in_env, secret
+
 
 Exceptions
 ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,7 @@ Secrets
       Please note that `it's a bad idea to store secrets in environment variables <https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/>`_.
 
 .. autoclass:: DirectorySecrets
-   :members: from_docker, from_path, from_path_in_env, secret
+   :members: from_path, from_path_in_env, secret
 
 
 Exceptions

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -27,11 +27,17 @@ from configparser import NoOptionError, RawConfigParser
 
 import attr
 
-from ._environ_config import CNF_KEY, RAISE, Raise, _ConfigEntry
+from ._environ_config import CNF_KEY, PY2, RAISE, Raise, _ConfigEntry
 from .exceptions import MissingSecretError
 
 
 log = logging.getLogger(__name__)
+
+
+if PY2:
+    FileOpenError = IOError
+else:
+    FileOpenError = OSError
 
 
 def _get_default_secret(var, default):
@@ -200,7 +206,7 @@ class DirectorySecrets(object):
             with _open_file(secret_path) as f:
                 val = f.read()
             return _SecretStr(val)
-        except OSError:
+        except FileOpenError:
             return _get_default_secret(filename, ce.default)
 
 

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -155,13 +155,6 @@ class DirectorySecrets(object):
     _env_name = attr.ib(default=None)
 
     @classmethod
-    def from_docker(cls):
-        """
-        Read from Docker secrets default directory in a container.
-        """
-        return cls("/run/secrets/")
-
-    @classmethod
     def from_path(cls, path):
         """
         Look for secrets in *path* directory.

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -44,6 +44,10 @@ def _get_default_secret(var, default):
     return default
 
 
+def _open_file(path):
+    return codecs.open(path, mode="r", encoding="utf-8")
+
+
 @attr.s
 class INISecrets(object):
     """
@@ -202,7 +206,7 @@ def _load_ini(path):
     Load an INI file from *path*.
     """
     cfg = RawConfigParser()
-    with codecs.open(path, mode="r", encoding="utf-8") as f:
+    with _open_file(path) as f:
         cfg.read_file(f)
 
     return cfg

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -147,6 +147,8 @@ class DirectorySecrets(object):
     Load secrets from a directory containing secrets in separate files.
     Suitable for reading Docker or Kubernetes secrets
     from the filesystem inside a container.
+
+    .. versionadded:: 21.1.0
     """
 
     secrets_dir = attr.ib()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -20,7 +20,12 @@ import pytest
 import environ
 
 from environ.exceptions import MissingSecretError
-from environ.secrets import INISecrets, VaultEnvSecrets, _SecretStr
+from environ.secrets import (
+    DirectorySecrets,
+    INISecrets,
+    VaultEnvSecrets,
+    _SecretStr,
+)
 
 
 class TestSecretStr:
@@ -238,3 +243,97 @@ class TestVaultEnvSecrets(object):
         cfg = environ.to_config(Cfg, fake_environ)
 
         assert _SecretStr("foo") == cfg.pw
+
+
+@pytest.fixture
+def secrets_dir(tmpdir):
+    def make_secrets_file(name, content):
+        secret_file = tmpdir.join(name)
+        secret_file.write(content)
+
+    make_secrets_file("empty", "")
+    make_secrets_file("apples", "apples\n")
+    make_secrets_file("oranges", "oranges")
+    return str(tmpdir)
+
+
+class TestDirectorySecrets(object):
+    def test_secret_content(self, secrets_dir):
+        """
+        Reading secrets with different content.
+        """
+        dir = DirectorySecrets.from_path(secrets_dir)
+
+        @environ.config
+        class Cfg(object):
+            empty = dir.secret()
+            apples = dir.secret()
+            oranges = dir.secret()
+
+        cfg = environ.to_config(Cfg, {})
+
+        assert _SecretStr("") == cfg.empty
+        assert _SecretStr("apples\n") == cfg.apples
+        assert _SecretStr("oranges") == cfg.oranges
+
+    def test_secret_different_name(self, secrets_dir):
+        """
+        Attribute names can be different than filenames,
+        the name argument can be used to select the filename.
+        """
+        dir = DirectorySecrets.from_path(secrets_dir)
+
+        @environ.config
+        class Cfg(object):
+            nothing = dir.secret(name="empty")
+            has_newline = dir.secret(name="apples")
+            no_newline = dir.secret(name="oranges")
+
+        cfg = environ.to_config(Cfg, {})
+
+        assert _SecretStr("") == cfg.nothing
+        assert _SecretStr("apples\n") == cfg.has_newline
+        assert _SecretStr("oranges") == cfg.no_newline
+
+    def test_secret_from_env(self, secrets_dir):
+        """
+        A directory can be specified in an environment variable.
+        """
+        dir = DirectorySecrets.from_path_in_env("SECRETS_DIR", "/tmp")
+
+        @environ.config
+        class Cfg(object):
+            apples = dir.secret()
+
+        cfg = environ.to_config(Cfg, {"SECRETS_DIR": secrets_dir})
+        assert _SecretStr("apples\n") == cfg.apples
+
+    def test_missing_default_value(self, tmpdir):
+        """
+        Missing secrets should raise Exceptions when loading the config.
+        """
+        dir = DirectorySecrets.from_path(str(tmpdir))
+
+        @environ.config
+        class Cfg(object):
+            doesnt_exist = dir.secret()
+
+        with pytest.raises(MissingSecretError):
+            environ.to_config(Cfg, {})
+
+    def test_default_value_specified(self, tmpdir):
+        """
+        Default values work for DirectorySecrets too.
+        """
+        dir = DirectorySecrets.from_path(str(tmpdir))
+
+        @environ.config
+        class Cfg(object):
+            doesnt_exist = dir.secret(default="Test default value")
+
+        cfg = environ.to_config(Cfg, {})
+        assert "Test default value" == cfg.doesnt_exist
+
+    def test_from_docker(self):
+        dir = DirectorySecrets.from_docker()
+        assert "/run/secrets/" == dir.secrets_dir

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -333,7 +333,3 @@ class TestDirectorySecrets(object):
 
         cfg = environ.to_config(Cfg, {})
         assert "Test default value" == cfg.doesnt_exist
-
-    def test_from_docker(self):
-        dir = DirectorySecrets.from_docker()
-        assert "/run/secrets/" == dir.secrets_dir


### PR DESCRIPTION
Hello!

We would like to use this library in production.
We deploy to Docker Swarm currently and using Docker secrets, which mounts them into the container under `/run/secrets`.
This pull request implements a `DirectorySecrets` reader, which given a directory, can read individual files from it. 
Works the same way as `INISecrets`.


# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/environ-config/blob/master/.github/CONTRIBUTING.rst) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/environ-config/blob/master/src/environ_config/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
