### PR TITLE
Require 100% coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -80,4 +80,4 @@ deps = coverage[toml]
 skip_install = true
 commands =
     coverage combine
-    coverage report
+    coverage report --fail-under=100


### PR DESCRIPTION
The Pull Request is checked for 100% coverage, but tox environment
did not have this set, so it was possible to run every tox test
without errors, but the GitHub pipeline would still fail.

