### PR TITLE
testing: allow lazy init of boto client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     env:
-      USING_COVERAGE: '2.7,3.8'
+      USING_COVERAGE: '3.8'
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10.0-alpha - 3.10"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10.0-alpha - 3.10"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ The third digit is only for regressions.
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*none*
+- Python 2.7 support dropped
 
 
 Deprecations:
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Lazily init the AWS SecretsManager client to make unit testing easier.
+  `#25 <https://github.com/hynek/environ-config/pull/25>`_
 
 
 ----

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -16,14 +16,11 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
-import sys
 
 import attr
 
 from .exceptions import MissingEnvValueError
 
-
-PY2 = sys.version_info[0] == 2
 
 CNF_KEY = "environ_config"
 log = logging.getLogger(CNF_KEY)
@@ -37,9 +34,6 @@ class Sentinel(object):
 
     def __bool__(self):
         return self._bool
-
-    if PY2:
-        __nonzero__ = __bool__
 
 
 PREFIX_NOT_SET = Sentinel(False)

--- a/src/environ/secrets/__init__.py
+++ b/src/environ/secrets/__init__.py
@@ -26,7 +26,7 @@ from configparser import NoOptionError, RawConfigParser
 
 import attr
 
-from environ._environ_config import CNF_KEY, PY2, RAISE, _ConfigEntry
+from environ._environ_config import CNF_KEY, RAISE, _ConfigEntry
 from environ.exceptions import MissingSecretImplementationError
 
 from ._utils import _get_default_secret, _open_file
@@ -46,10 +46,7 @@ except ImportError:  # pragma: nocover
 log = logging.getLogger(__name__)
 
 
-if PY2:
-    FileOpenError = IOError
-else:
-    FileOpenError = OSError
+FileOpenError = OSError
 
 
 @attr.s

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ filterwarnings =
 # Keep docs in sync with docs env and .readthedocs.yml.
 [gh-actions]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37, docs
@@ -20,7 +19,7 @@ python =
 
 
 [tox]
-envlist = lint,py27,py35,py36,py37,py38-oldestAttrs,py38,py39,py310,manifest,docs,pypi-description,coverage-report
+envlist = lint,py35,py36,py37,py38-oldestAttrs,py38,py39,py310,manifest,docs,pypi-description,coverage-report
 isolated_build = true
 
 [testenv:lint]


### PR DESCRIPTION
Initializing the SecretsManager as an attr factory caused the client to
be initialized too early to mock it out with moto for unit testing, as
was called out in #24.

Until python-attrs/attrs#573 is fixed, we need to manually lazy-init the
client for SecretsManager

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/environ-config/blob/main/.github/CONTRIBUTING.rst) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/environ-config/blob/main/src/environ_config/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
