### PR TITLE
Add type hints for public APIs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,10 +11,11 @@ If an item doesn't apply to your pull request, **check it anyway** to make it ap
 -->
 
 - [ ] Added **tests** for changed code.
+- [ ] **New or changed APIs** are added to [`typing_examples.py`](https://github.com/hynek/environ-config/blob/main/typing_examples.py).
 - [ ] Updated **documentation** for changed code.
-    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
+    - [ ] New functions/classes have to be added to `docs/api.md` by hand.
     - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
-- [ ] Documentation in `.md`  and `.rst` files are written using [*semantic newlines*](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
+- [ ] Documentation in `.md` files are written using [*semantic newlines*](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
 - [ ] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/main/CHANGELOG.md).
 
 <!--

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,27 @@ jobs:
           path: htmlcov
         if: ${{ failure() }}
 
+  mypy:
+    name: mypy on ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade wheel nox
+
+      - run: python -Im nox -e mypy
   docs:
     name: Build docs & run doctests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Whenever there is a need to break compatibility, it is announced here in the cha
 
 - `environ.secrets.DirectorySecrets.from_path()` now works when loading from `os.environ`.
   [#45](https://github.com/hynek/environ-config/issues/45)
+- Public APIs now carry type hints (except in-class methods like ``AppConfig.from_environ()``).
+  [#49](https://github.com/hynek/environ-config/issues/49)
 
 
 ## [22.1.0](https://github.com/hynek/environ-config/compare/21.2.0...22.1.0) - 2022-04-02

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@ from importlib import metadata
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "notfound.extension",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,11 +71,15 @@ exclude_patterns = ["_build"]
 default_role = "any"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-# add_function_parentheses = True
+add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
 # add_module_names = True
+
+# Move type hints into the description block, instead of the func definition.
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,13 @@ def coverage_report(session: nox.Session) -> None:
     session.run("coverage", "report")
 
 
+@nox.session
+def mypy(session: nox.Session) -> None:
+    session.install(".", "mypy")
+
+    session.run("mypy", "typing_examples.py")
+
+
 # Keep python in sync with ci.yml/docs and .readthedocs.yaml.
 @nox.session(python="3.10")
 def docs(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,19 @@ target-version = ["py37"]
 [tool.isort]
 profile = "attrs"
 
+
+[tool.mypy]
+strict = true
+
+show_error_codes = true
+enable_error_code = ["ignore-without-code"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true
+
+
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"
 

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -70,19 +70,19 @@ def config(
     """
     Make a class a configuration class.
 
-    :param str prefix: The prefix that is used for the env variables.  If you
-        have an `var` attribute on the class and you leave the default argument
+    :param prefix: The prefix that is used for the env variables.  If you have
+        an `var` attribute on the class and you leave the default argument
         value of *PREFIX_NOT_SET*, the *DEFAULT_PREFIX* value of ``APP`` will
         be used and *environ-config* will look for an environment variable
         called ``APP_VAR``.
-    :param str from_environ: If not `None`, attach a config loading method with
-        the name *from_environ* to the class.  See `to_config` for more
+    :param from_environ: If not `None`, attach a config loading method with the
+        name *from_environ* to the class.  See `to_config` for more
         information.
-    :param str generate_help: If not `None`, attach a config loading method
-        with the name *generate_help* to the class.  See `generate_help` for
-        more information.
-    :param bool frozen: The configuration will be immutable after
-        instantiation, if `True`.
+    :param generate_help: If not `None`, attach a config loading method with
+        the name *generate_help* to the class.  See `generate_help` for more
+        information.
+    :param frozen: The configuration will be immutable after instantiation, if
+        `True`.
 
     .. versionadded:: 19.1.0
        *from_environ*
@@ -114,7 +114,7 @@ def config(
     return wrap(maybe_cls)
 
 
-@attr.s(slots=True, auto_attribs=True)
+@attr.s(slots=True)
 class _ConfigEntry:
     name: str | None = attr.ib(default=None)
     default: Any = attr.ib(default=RAISE)
@@ -138,17 +138,17 @@ def var(
 
     :param default: Setting this to a value makes the config attribute
         optional.
-    :param str name: Overwrite name detection with a string.  If not set, the
-        name of the attribute is used.
-    :param converter: A callable that is run with the found value and
-        its return value is used.  Please not that it is also run for default
+    :param name: Overwrite name detection with a string.  If not set, the name
+        of the attribute is used.
+    :param converter: A callable that is run with the found value and its
+        return value is used.  Please not that it is also run for default
         values.
-    :param validator: A callable that is run with the final value.
-        See *attrs*'s `chapter on validation
+    :param validator: A callable that is run with the final value. See
+        *attrs*'s `chapter on validation
         <https://www.attrs.org/en/stable/init.html#validators>`_ for details.
         You can also use any validator that is `shipped with attrs
         <https://www.attrs.org/en/stable/api.html#validators>`_.
-    :param str help: A help string that is used by `generate_help`.
+    :param help: A help string that is used by `generate_help`.
     """
     return attr.ib(
         default=default,
@@ -216,7 +216,7 @@ def group(cls: type[T], optional: bool = False) -> T:
     (including sub-groups) are not present in the environment being parsed, the
     attribute corresponding to the *optional* *group* will be set to `None`.
 
-    :param bool optional: Mark this group as *optional*. Defaults to `False`.
+    :param optional: Mark this group as *optional*. Defaults to `False`.
 
     :returns: An attribute which will be used as a nested *group* of variables.
 
@@ -309,7 +309,7 @@ def to_config(config_cls: type[T], environ: dict[str, str] = os.environ) -> T:
     Load the configuration as declared by *config_cls* from *environ*.
 
     :param config_cls: The configuration class to fill.
-    :param dict environ: Source of the configuration.  `os.environ` by default.
+    :param environ: Source of the configuration.  `os.environ` by default.
 
     :returns: An instance of *config_cls*.
 
@@ -323,7 +323,7 @@ def to_config(config_cls: type[T], environ: dict[str, str] = os.environ) -> T:
 
 def _format_help_dicts(help_dicts, display_defaults=False):
     """
-    Format the output of _generate_help_dicts into a str
+    Format the output of _generate_help_dicts into a str.
     """
     help_strs = []
     for help_dict in help_dicts:
@@ -344,8 +344,8 @@ def _format_help_dicts(help_dicts, display_defaults=False):
 
 def _generate_var_name(prefix, field_name):
     """
-    Generate the environment variable name, given a prefix
-    and the configuration field name.
+    Generate the environment variable name, given a prefix and the
+    configuration field name.
 
     Examples:
 

--- a/src/environ/secrets/awssm.py
+++ b/src/environ/secrets/awssm.py
@@ -15,7 +15,12 @@
 """
 Handling of sensitive data stored in AWS Secrets Manager
 """
+
+from __future__ import annotations
+
 import logging
+
+from typing import Any, Callable
 
 import attr
 import boto3
@@ -43,7 +48,7 @@ def _build_secretsmanager_client():
     return client
 
 
-@attr.s(init=False)
+@attr.s(auto_attribs=True)
 class SecretsManagerSecrets:
     """
     Load secrets from the *AWS Secrets Manager*.
@@ -59,21 +64,21 @@ class SecretsManagerSecrets:
     .. versionadded:: 21.4.0
     """
 
-    def __init__(self, client=None):
-        self._client = client
+    _client: boto3.client | None = None
 
     @property
-    def client(self):
+    def client(self) -> boto3.client:
         if self._client is None:
             self._client = _build_secretsmanager_client()
+
         return self._client
 
     def secret(
         self,
-        default=RAISE,
-        converter=convert_secret("SecretString"),
-        name=None,
-        help=None,
+        default: Any = RAISE,
+        converter: Callable = convert_secret("SecretString"),
+        name: str | None = None,
+        help: str | None = None,
     ):
         """
         Declare a secrets manager secret on an `environ.config`-decorated class

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -1,0 +1,26 @@
+import environ
+
+
+@environ.config
+class Config:
+    @environ.config
+    class Sub:
+        y: int = environ.var(converter=int)
+
+    x: str = environ.var()
+    sub: Sub = environ.group(Sub)
+
+
+cfg = environ.to_config(Config, {"APP_X": "123"})
+
+
+def takes_cfg(c: Config) -> str:
+    return c.x
+
+
+def takes_sub(s: Config.Sub) -> int:
+    return cfg.sub.y
+
+
+x: str = takes_cfg(cfg)
+y: int = takes_sub(cfg.sub)

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -8,8 +8,11 @@ class Config:
         y: int = environ.var(converter=int)
 
     x: str = environ.var()
+    b: bool = environ.bool_var(name="BOOL")
     sub: Sub = environ.group(Sub)
 
+
+s: str = environ.generate_help(Config)
 
 cfg = environ.to_config(Config, {"APP_X": "123"})
 
@@ -23,4 +26,5 @@ def takes_sub(s: Config.Sub) -> int:
 
 
 x: str = takes_cfg(cfg)
+b: bool = cfg.b
 y: int = takes_sub(cfg.sub)

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -1,6 +1,28 @@
 import environ
 
 
+ini_secrets: environ.secrets.INISecrets = (
+    environ.secrets.INISecrets.from_path_in_env(
+        "APP_SECRETS_INI", "/secrets/secrets.ini"
+    )
+)
+ini2: environ.secrets.INISecrets = environ.secrets.INISecrets.from_path(
+    "/secrets/secrets.ini", section="foo"
+)
+dir_secrets: environ.secrets.DirectorySecrets = (
+    environ.secrets.DirectorySecrets.from_path_in_env("APP_SECRETS_PATH", ".")
+)
+dir2: environ.secrets.DirectorySecrets = (
+    environ.secrets.DirectorySecrets.from_path(".")
+)
+vault_secrets: environ.secrets.VaultEnvSecrets = (
+    environ.secrets.VaultEnvSecrets("XYZ")
+)
+aws_secrets: environ.secrets.SecretsManagerSecrets = (
+    environ.secrets.SecretsManagerSecrets()
+)
+
+
 @environ.config
 class Config:
     @environ.config
@@ -10,9 +32,13 @@ class Config:
     x: str = environ.var()
     b: bool = environ.bool_var(name="BOOL")
     sub: Sub = environ.group(Sub)
+    secret: str = ini_secrets.secret()
+    d_secret: str = dir_secrets.secret(help="help!")
+    v_secret: str = vault_secrets.secret()
+    a_secret: str = aws_secrets.secret()
 
 
-s: str = environ.generate_help(Config)
+h: str = environ.generate_help(Config)
 
 cfg = environ.to_config(Config, {"APP_X": "123"})
 
@@ -28,3 +54,7 @@ def takes_sub(s: Config.Sub) -> int:
 x: str = takes_cfg(cfg)
 b: bool = cfg.b
 y: int = takes_sub(cfg.sub)
+s: str = cfg.secret
+ds: str = cfg.d_secret
+vs: str = cfg.v_secret
+as_: str = cfg.a_secret


### PR DESCRIPTION
I'm too ~busy~ lazy to add stubs for everything, but this should work for most people without resorting to Mypy plugins etc?