### PR TITLE
Support moto 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = ["attrs>=17.4.0", "importlib_metadata; python_version<'3.8'"]
 
 [project.optional-dependencies]
-tests = ["pytest", "moto<4.2.1"]
+tests = ["pytest", "moto"]
 aws = ["boto3"]
 docs = [
     "environ-config[aws]",

--- a/tests/test_secrets_awssm.py
+++ b/tests/test_secrets_awssm.py
@@ -23,7 +23,7 @@ import attr
 import boto3
 import pytest
 
-from moto import mock_secretsmanager
+from moto import mock_aws
 
 import environ
 
@@ -62,7 +62,7 @@ def _mock_aws_credentials(force_region):
 
 @pytest.fixture(name="secretsmanager")
 def _secretsmanager():
-    with mock_secretsmanager():
+    with mock_aws():
         yield boto3.client("secretsmanager", region_name="us-east-2")
 
 
@@ -122,7 +122,7 @@ class TestAWSSMSecret:
         class Cfg:
             pw = sm.secret()
 
-        with mock_secretsmanager():
+        with mock_aws():
             # we need to make sure we're using the same region. It doesn't
             # matter which -- moto _and_ boto will try figure it out from the
             # environment -- but it has to be the same.


### PR DESCRIPTION
moto 5.0 has been released, and the major change is to pull all of the mocking into one function. Use the new mock_aws function, but continue to support moto 4.2, since it's easy.

- [x] Added **tests** for changed code.
- [x] **New or changed APIs** are added to our [typing examples](https://github.com/hynek/environ-config/blob/main/tests/typing/api.py) to ensure our external type hints are sound.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.md` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Documentation in `.md` files are written using [*semantic newlines*](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/main/CHANGELOG.md).
