### PR TITLE
docs: add a brief example of the indirection behaviour in secretsmanager

### DIFF
--- a/src/environ/secrets/awssm.py
+++ b/src/environ/secrets/awssm.py
@@ -52,10 +52,26 @@ def _build_secretsmanager_client():
 
 @attr.s(auto_attribs=True)
 class SecretsManagerSecrets:
-    """
-    Load secrets from the AWS Secrets Manager.
+    """Load secrets from the AWS Secrets Manager.
 
-    The secret name should be stored in the environment variable
+    The secret ID should be stored in the environment variable by name:
+
+    Given this environment::
+
+        export APP_MY_SECRET=prod/db_password
+        export APP_A_DIFFERENT_NAME=prod/api_key
+
+    And this app::
+
+        sm = SecretsManagerSecrets()
+
+        @environ.config
+        class Cfg:
+            my_secret = sm.secret()
+            my_aliased_secret = sm.secret(name="A_DIFFERENT_NAME")
+
+    Then the secrets will be looked up in AWS Secrets Manager with the Secret IDs
+    ``prod/db_password`` and ``prod/api_key``, respectively.
 
     .. warning::
 
@@ -64,6 +80,7 @@ class SecretsManagerSecrets:
        environ-config[aws]``
 
     .. versionadded:: 21.4.0
+
     """
 
     _client: boto3.client | None = None

--- a/src/environ/secrets/awssm.py
+++ b/src/environ/secrets/awssm.py
@@ -52,7 +52,8 @@ def _build_secretsmanager_client():
 
 @attr.s(auto_attribs=True)
 class SecretsManagerSecrets:
-    """Load secrets from the AWS Secrets Manager.
+    """
+    Load secrets from the AWS Secrets Manager.
 
     The secret ID should be stored in the environment variable by name:
 
@@ -70,8 +71,8 @@ class SecretsManagerSecrets:
             my_secret = sm.secret()
             my_aliased_secret = sm.secret(name="A_DIFFERENT_NAME")
 
-    Then the secrets will be looked up in AWS Secrets Manager with the Secret IDs
-    ``prod/db_password`` and ``prod/api_key``, respectively.
+    Then the secrets will be looked up in AWS Secrets Manager with the Secret
+    IDs ``prod/db_password`` and ``prod/api_key``, respectively.
 
     .. warning::
 
@@ -80,7 +81,6 @@ class SecretsManagerSecrets:
        environ-config[aws]``
 
     .. versionadded:: 21.4.0
-
     """
 
     _client: boto3.client | None = None


### PR DESCRIPTION
# Summary

This indirection generated some confusion (see https://github.com/hynek/environ-config/issues/129) so hopefully it's cleared up a bit.

# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] **New or changed APIs** are added to our [typing examples](https://github.com/hynek/environ-config/blob/main/tests/typing/api.py) to ensure our external type hints are sound.
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.md` by hand.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [X] Documentation in `.md` files are written using [*semantic newlines*](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/environ-config/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
